### PR TITLE
moveit_hybrid_planning bugfix

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -218,7 +218,7 @@ install(
 )
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS} orocos_kdl_vendor)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # Plugin exports
 pluginlib_export_plugin_description_file(moveit_core collision_detector_fcl_description.xml)

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -65,7 +65,7 @@
   <test_depend>moveit_resources_pr2_description</test_depend>
   <test_depend>angles</test_depend>
   <test_depend>tf2_kdl</test_depend>
-  <test_depend>orocos_kdl_vendor</test_depend>
+  <test_depend>orocos_kdl</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_index_cpp</test_depend>
 

--- a/moveit_kinematics/CMakeLists.txt
+++ b/moveit_kinematics/CMakeLists.txt
@@ -67,7 +67,7 @@ install(
 )
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
-ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS} orocos_kdl_vendor)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/moveit_kinematics/package.xml
+++ b/moveit_kinematics/package.xml
@@ -30,7 +30,7 @@
   <depend>eigen</depend>
   <depend>tf2</depend>
   <depend>tf2_kdl</depend>
-  <depend>orocos_kdl_vendor</depend>
+  <depend>orocos_kdl</depend>
   <depend>moveit_msgs</depend>
 
   <!-- some requirements of ikfast scripts -->

--- a/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
+++ b/moveit_planners/pilz_industrial_motion_planner/CMakeLists.txt
@@ -193,7 +193,7 @@ ament_export_include_directories(
   include
 )
 ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
-ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS} orocos_kdl_vendor)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 if(BUILD_TESTING)
   # Include Tests

--- a/moveit_planners/pilz_industrial_motion_planner/package.xml
+++ b/moveit_planners/pilz_industrial_motion_planner/package.xml
@@ -28,7 +28,7 @@
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning</depend> <!-- RobotModelLoader -->
   <depend>moveit_ros_move_group</depend> <!-- move_group capability -->
-  <depend>orocos_kdl_vendor</depend>
+  <depend>orocos_kdl</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>

--- a/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
+++ b/moveit_ros/hybrid_planning/local_planner/local_planner_component/src/local_planner_component.cpp
@@ -419,8 +419,7 @@ void LocalPlannerComponent::executeIteration()
         rclcpp::Duration waypoint_duration = rclcpp::Duration(local_solution.points.at(0).time_from_start);
         // Apply latency compensation to publish a bit sooner. This compensates for ROS message latency
         // so the controller command arrives exactly when it should.
-        waypoint_duration = rclcpp::Duration(waypoint_duration.nanoseconds() +
-          rclcpp::Duration::from_seconds(config_.latency_compensation_seconds).nanoseconds());
+        waypoint_duration = waypoint_duration + rclcpp::Duration::from_seconds(config_.latency_compensation_seconds);
         time_to_send_next_wypt_ = current_time + waypoint_duration;
         prev_command_ = local_solution;
       }


### PR DESCRIPTION
### Description
This MR fixes a bug that causes moveit_hybrid_planning to fail to build on humble and rolling (potentially other distros as well). The culprit seems to be that it is no longer possible to create a `rclcpp::Duration` object from *rcl_duration_value_t* nanoseconds. This seems to be deprecated in [this](https://github.com/ros2/rclcpp/commit/6815022909086487f2b8dc14c0540b00d4cf61a0#diff-8c342d6e20a9d6406355b891079214cc82a93be127b6a0871c3586bebb13fd0aL41-L47) commit. My guess as to why this issue is only showing up now (as that commit was made on April 8) was that the rclcpp debian was not updated with that change until very recently.

Tested by building MoveIt from source in Docker image and verified that moveit_hybrid_planning builds successfully.

Also tested changes by running in BRO.